### PR TITLE
Added two new arguments to simplify command line call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ ${binPath}/ortheus_core : *.c *.h xyzModelC.c xyzModelC.h ${basicLibsDependencie
 # jobs
 xyzModelC.c xyzModelC.h : ${model} ${paramModel} TransducerComposer.py TransducerCompiler.py
 	rm -f model.otra xyzModelC.c xyzModelC.h ${modelPath}/model.dot ${modelPath}/ortheusmodel.pdf
-	python TransducerComposer.py ${model} temp.otra ${modelPath}/model.dot ${collapseCoefficient} </dev/null
+	python2 TransducerComposer.py ${model} temp.otra ${modelPath}/model.dot ${collapseCoefficient} </dev/null
 	cat  ${paramModel} temp.otra > model.otra
 	rm temp.otra
-	python  TransducerCompiler.py model.otra xyzModelC.c xyzModelC.h </dev/null
+	python2  TransducerCompiler.py model.otra xyzModelC.c xyzModelC.h </dev/null
 	#Use this line if you want the pretty picture
 	#${makeGraph} ${modelPath}/model.dot -Tpdf > ${modelPath}/model.pdf
   
 test :
 	#Running python allTests.py
-	PYTHONPATH=.. PATH=../../bin:$$PATH python allTests.py --testLength=SHORT --logDebug
+	PYTHONPATH=.. PATH=../../bin:$$PATH python2 allTests.py --testLength=SHORT --logDebug


### PR DESCRIPTION
To avoid problems with extremely large command lines when the number of fasta files is really high (above 10k files), I have added two new arguments (named `-A` and `-B` after their existing counterparts) to pass the large list of fasta files inside a text file (`-A`) and the newick tree string inside another file (`-B`).

I have also added a explicit call to Python 2 in the Makefile because the existing code doesn't compile in Python 3 (may need to be updated with the upcoming Python 2.7 EOL).